### PR TITLE
Support for commands via file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,40 @@ it gets even simpler:
 ```
 
 
+## Command via file input
+
+This resource supports file inputs.  This allows the pipeline to parameterize and generate commands during pipeline execution.
+
+* `file`: *Optional.* Contains path to a YAML file that contains the same fields as `params`; including `command` and `commands`.  If used, this resource uses only the configuration listed in this file.  All other configurations specified in the `params` section will be ignored. The `file` field (if exists) is ignored within the content of the file itself.
+
+```yml
+  - task: configure
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: ubuntu
+      run:
+        path: bash
+        args:
+        - -excl
+        - |-
+          cat > cf_command/params.yml <<EOF
+          command: delete
+          app_name: app
+          delete_mapped_routes: true
+          EOF
+      outputs:
+        - name: cf_command
+  - put: cf-delete
+    resource: cf-env
+    params:
+      command: delete
+      file: cf_command/params.yml
+```
+
+
 ## Behavior
 
 ### `out`: Run a cf cli command.

--- a/assets/out
+++ b/assets/out
@@ -17,7 +17,7 @@ if [ -z "$working_dir" ]; then
 fi
 
 # for jq
-PATH=/usr/local/bin:$PATH
+PATH=/usr/local/bin:$PATH:.
 
 TMPDIR=${TMPDIR:-/tmp}
 payload=$(mktemp "$TMPDIR/cf-cli-resource-request.XXXXXX")
@@ -40,6 +40,7 @@ params=$(jq -r '.params //empty' < $payload)
 cf_color=$(jq -r '.source.cf_color //empty' < $payload) && [ -n "$cf_color" ] && export CF_COLOR=$cf_color
 cf_dial_timeout=$(jq -r '.source.cf_dial_timeout //empty' < $payload) && [ -n "$cf_dial_timeout" ] && export CF_DIAL_TIMEOUT=$cf_dial_timeout
 cf_trace=$(jq -r '.source.cf_trace //empty' < $payload) && echo "$cf_trace" | grep -qi 'true' && export CF_TRACE=true
+file=$(echo "$params" | jq -r '.file //empty')
 
 if [ -z "$api" ]; then
   printf '\e[91m[ERROR]\e[0m invalid payload (missing api)\n'
@@ -57,6 +58,15 @@ if [ -z "$password" ]; then
 fi
 
 cd "$working_dir"
+
+if [ -n "$file" ]; then
+  printf '\e[92m[INFO]\e[0m %s\n' "Populating params from file (overwriting params in pipeline definition): "$file""
+  yaml_content=$(cat "$file")
+  printf '\e[92m[INFO]\e[33mOriginal content\e[0m: \n%s\n' "$yaml_content"
+  params=$(yq r -j "$file")
+  printf '\e[92m[INFO]\e[33mJson representation\e[0m: \n%s\n' "$params"
+fi
+
 
 printf '\e[92m[INFO]\e[0m %s\n' "$(cf --version)"
 

--- a/itest/run-all-tests
+++ b/itest/run-all-tests
@@ -17,3 +17,4 @@ $test_dir/run-asynchronous-service-tests
 $test_dir/run-share-service-tests
 $test_dir/run-task-tests
 $test_dir/run-user-tests
+$test_dir/run-file-tests

--- a/itest/run-file-tests
+++ b/itest/run-file-tests
@@ -1,0 +1,229 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+test_dir=$(dirname $0)
+
+source $test_dir/assert.sh
+source $test_dir/helpers.sh
+source $test_dir/config.sh
+
+it_can_push_an_app_no_start_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+  create_static_app "$3" "$working_dir"
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "push"
+		org: "$1"
+		space: "$2"
+		app_name: "$3"
+		path: "static-*/content"
+		manifest: "static-app/manifest.yml"
+		no_start: "true"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  assert::success cf_is_app_stopped "$3"
+}
+
+it_can_start_an_app_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "start"
+		org: "$1"
+		space: "$2"
+		app_name: "$3"
+		staging_timeout: 15
+		startup_timeout: 5
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  assert::success cf_is_app_started "$3"
+}
+
+it_can_stop_an_app_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "stop"
+		org: "$1"
+		space: "$2"
+		app_name: "$3"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+  assert::success cf_is_app_stopped "$3"
+}
+
+it_can_delete_an_app_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "delete"
+		org: "$1"
+		space: "$2"
+		app_name: "$3"
+		delete_mapped_routes: "true"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  ! cf_app_exists "$3"
+}
+
+it_can_create_an_org_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "create-org"
+		org: "$1"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  cf_org_exists "$1"
+}
+
+it_can_create_a_space_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		command: "create-space"
+		org: "$1"
+		space: "$2"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  cf_space_exists "$1" "$2"
+}
+
+# This test showcases the multi-command syntax
+it_can_delete_a_space_and_org_with_file() {
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+	cat > "$working_dir/params.yml" <<-EOF
+		commands:
+		- command: "delete-space"
+		  org: "$1"
+		  space: "$2"
+		- command: "delete-org"
+		  org: "$1"
+	EOF
+
+  local params=$(jq -n \
+  --arg dir "$working_dir/params.yml" \
+  '{
+    command: "invalid-XXXXXX",
+    file: $dir
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+
+  put_with_params "$config" "$working_dir" | jq -e '
+    .version | keys == ["timestamp"]
+  '
+
+  ! cf_space_exists "$1" "$2"
+  ! cf_org_exists "$1"
+}
+
+
+setup_integration_tests_with_file() {
+  local org=${1:?org null or not set}
+  local space=${2:?space null or not set}
+
+  run it_can_create_an_org_with_file \"$org\"
+  run it_can_create_a_space_with_file \"$org\" \"$space\"
+}
+
+teardown_integration_tests_with_file() {
+  local org=${1:?org null or not set}
+  local space=${2:?space null or not set}
+
+  run it_can_delete_a_space_and_org_with_file \"$org\" \"$space\"
+}
+
+org=$(generate_test_name_with_spaces "Org")
+space=$(generate_test_name_with_spaces "Space")
+app_name=$(generate_test_name_with_spaces "App")
+
+setup_integration_tests_with_file "$org" "$space"
+
+run it_can_push_an_app_no_start_with_file \"$org\" \"$space\" \"$app_name\"
+run it_can_start_an_app_with_file \"$org\" \"$space\" \"$app_name\"
+run it_can_stop_an_app_with_file \"$org\" \"$space\" \"$app_name\"
+run it_can_delete_an_app_with_file \"$org\" \"$space\" \"$app_name\"
+
+teardown_integration_tests_with_file "$org" "$space"


### PR DESCRIPTION
This is to support parameterization of the parameters.

The resource should now be able to accept a file that has the same structure as `params` and act accordingly based on the results of previous pipeline stages (e.g. name of services etc.)