### PR TITLE
Fix `out` script to work for `command_file` param

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -14,6 +14,8 @@ working_dir=${1:-}
 if [ -z "$working_dir" ]; then
   printf '\e[91m[ERROR]\e[0m usage: %s <path/to/source>\n' "$0"
   exit 1
+else
+  cd $1
 fi
 
 # for jq


### PR DESCRIPTION
- cd to source directory so $command_file param is a valid relative path