### PR TITLE
 Optional port/protocol in add-network-policy

### DIFF
--- a/assets/cf-functions.sh
+++ b/assets/cf-functions.sh
@@ -762,8 +762,8 @@ function cf_rename() {
 function cf_add_network_policy() {
   local source_app=${1:?source_app null or not set}
   local destination_app=${2:?destination_app null or not set}
-  local protocol=${3:?protocol null or not set}
-  local port=${4:?port null or not set}
+  local protocol=$3
+  local port=$4
 
   local args=("$source_app" --destination-app "$destination_app")
   [ -n "$protocol" ] && args+=(--protocol "$protocol")

--- a/itest/run-network-policy-tests
+++ b/itest/run-network-policy-tests
@@ -38,6 +38,33 @@ it_can_add_network_policy() {
   assert::success cf_network_policy_exists "$source_app_name" "$destination_app_name" "udp" "9999"
 }
 
+it_can_add_network_policy_with_defaults() {
+  local org=${1:?org null or not set}
+  local space=${2:?space null or not set}
+  local source_app_name=${3:?source_app_name null or not set}
+  local destination_app_name=${4:?destination_app_name null or not set}
+
+  local working_dir=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+  local params=$(jq -n \
+  --arg org "$org" \
+  --arg space "$space" \
+  --arg source_app "$source_app_name" \
+  --arg destination_app "$destination_app_name" \
+  '{
+    command: "add-network-policy",
+    org: $org,
+    space: $space,
+    source_app: $source_app,
+    destination_app: $destination_app,
+  }')
+
+  local config=$(echo $source | jq --argjson params "$params" '.params = $params')
+  put_with_params "$config" "$working_dir" | jq -e '.version | keys == ["timestamp"]'
+
+  assert::success cf_network_policy_exists "$source_app_name" "$destination_app_name" "tcp" "8080"
+}
+
 it_can_remove_network_policy() {
   local org=${1:?org null or not set}
   local space=${2:?space null or not set}
@@ -78,6 +105,7 @@ run it_can_push_an_app \"$org\" \"$space\" \"$source_app_name\"
 run it_can_push_an_app \"$org\" \"$space\" \"$destination_app_name\"
 
 run it_can_add_network_policy \"$org\" \"$space\" \"$source_app_name\" \"$destination_app_name\"
+run it_can_add_network_policy_with_defaults \"$org\" \"$space\" \"$source_app_name\" \"$destination_app_name\"
 run it_can_remove_network_policy \"$org\" \"$space\" \"$source_app_name\" \"$destination_app_name\"
 
 run it_can_delete_an_app \"$org\" \"$space\" \"$destination_app_name\"


### PR DESCRIPTION
According to the readme (and implied in the '-n' checks), port and protocol were supposed to be optional on add-network-policy.

However, there were checks that prevented this behaviour. These checks have now been removed.