### PR TITLE
Allow specifying a custom domain on push

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ Push a new app or sync changes to an existing app
 * `docker_password`: *Optional.* This should be the users password when authenticating against a protected docker registry
 * `manifest`: *Optional.* Path to manifest
 * `hostname`: *Optional.* Hostname (e.g. my-subdomain)
+* `domain`: *Optional.* Domain to use instead of the default (e.g. apps.internal, subdomain.example.com)
 * `instances`: *Optional.* Number of instances
 * `disk_quota`: *Optional.* Disk limit (e.g. 256M, 1024M, 1G)
 * `memory`: *Optional.* Memory limit (e.g. 256M, 1024M, 1G)

--- a/assets/out
+++ b/assets/out
@@ -318,6 +318,7 @@ echo "$params" | jq -c '.commands[]' | while read -r options; do
     docker_password=$(echo $options | jq -r '.docker_password //empty')
     manifest=$(echo $options | jq -r '.manifest //empty')
     hostname=$(echo $options | jq -r '.hostname //empty')
+    domain=$(echo $options | jq -r '.domain //empty')
     instances=$(echo $options | jq -r '.instances //empty')
     disk_quota=$(echo $options | jq -r '.disk_quota //empty')
     memory=$(echo $options | jq -r '.memory //empty')
@@ -338,6 +339,7 @@ echo "$params" | jq -c '.commands[]' | while read -r options; do
     [ -n "$docker_password" ] && export CF_DOCKER_PASSWORD="$docker_password"
     [ -n "$manifest" ]        && args+=(-f "$manifest")
     [ -n "$hostname" ]        && args+=(-n "$hostname")
+    [ -n "$domain" ]          && args+=(-d "$domain")
     [ -n "$instances" ]       && args+=(-i "$instances")
     [ -n "$disk_quota" ]      && args+=(-k "$disk_quota")
     [ -n "$memory" ]          && args+=(-m "$memory")


### PR DESCRIPTION
This adds the ability to specify a custom domain using the `-d` flag for `cf push`.