### PR TITLE
Add support for optional path in bind-route-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ Bind a service instance to an HTTP route
 - `domain`: _Required._ The domain to bind the route to
 - `service_instance`: _Required._ The service instance to bind the route to
 - `hostname`: _Optional._ Hostname used in combination with `domain` to specify the route to bind
+- `path`: _Optional._ Path for the HTTP route to bind
 
 ```yml
 - put: cf-bind-route-service
@@ -747,6 +748,7 @@ Bind a service instance to an HTTP route
     domain: example.com
     service_instance: mylogger
     hostname: myhost
+    path: foo
 ```
 
 #### enable-feature-flag

--- a/resource/commands/bind-route-service.sh
+++ b/resource/commands/bind-route-service.sh
@@ -2,8 +2,9 @@
 domain=$(get_option '.domain')
 service_instance=$(get_option '.service_instance')
 hostname=$(get_option '.hostname')
+path=$(get_option '.path')
 
 logger::info "Executing $(logger::highlight "$command"): $service_instance"
 
 cf::target "$org" "$space"
-cf::bind_route_service "$domain" "$service_instance" "$hostname"
+cf::bind_route_service "$domain" "$service_instance" "$hostname" "$path"

--- a/resource/lib/cf-functions.sh
+++ b/resource/lib/cf-functions.sh
@@ -674,9 +674,11 @@ function cf::bind_route_service() {
   local domain=${1:?domain null or not set}
   local service_instance=${2:?service_instance null or not set}
   local hostname=${3:-}
+  local path=${4:-}
 
   local args=("$domain" "$service_instance")
   [ -n "$hostname" ] && args+=(--hostname "$hostname")
+  [ -n "$path" ]     && args+=(--path "$path")
 
   cf::cf bind-route-service "${args[@]}"
 }


### PR DESCRIPTION
The `bind-route-service` command does not support the optional path parameter yet. So this PR fixes this.

Do let us know, if some tests needs to be added.

TIA