### PR TITLE
Add service_broker param to enable-service-access

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ Wait for a service instance to start
 Enable access to a service or service plan for one or all orgs
 
 - `service`: _Required._ The marketplace service name to enable
+- `broker`: _Optional._ Enable access to a service from a particular service broker. Required when service name is ambiguous
 - `access_org`: _Optional._ Enable access for a specified organization
 - `plan`: _Optional._ Enable access to a specified service plan
 
@@ -669,6 +670,7 @@ Enable access to a service or service plan for one or all orgs
   params:
     command: enable-service-access
     service: some-service
+    broker: some-service-broker
     access_org: myorg
     plan: simple
 ```

--- a/itest/run-service-broker-tests
+++ b/itest/run-service-broker-tests
@@ -91,15 +91,18 @@ it_can_enable_service_access() {
   local org=${1:?org null or not set}
   local space=${2:?space null or not set}
   local service=${3:?service null or not set}
-  local plan=${4:-}
-  local access_org=${5:-}
+  local broker=${4:-}
+  local plan=${5:-}
+  local access_org=${6:-}
 
   local params=$(jq -n \
     --arg service "$service" \
+    --arg broker "$broker" \
     --arg plan "$plan" \
     --arg access_org "$access_org" \
     '{
       command: "enable-service-access",
+      broker: $broker,
       service: $service,
       plan: $plan,
       access_org: $access_org

--- a/resource/commands/enable-service-access.sh
+++ b/resource/commands/enable-service-access.sh
@@ -1,6 +1,7 @@
 
 service_broker=$(get_option '.service_broker')
 service=$(get_option '.service')
+broker=$(get_option '.broker')
 plan=$(get_option '.plan')
 access_org=$(get_option '.access_org')
 
@@ -9,4 +10,4 @@ logger::info "Executing $(logger::highlight "$command"): $service"
 # backwards compatibility for deprecated 'service_broker' param (https://github.com/nulldriver/cf-cli-resource/issues/21)
 service=${service:-$service_broker}
 
-cf::enable_service_access "$service" "$plan" "$access_org"
+cf::enable_service_access "$service" "$broker" "$plan" "$access_org"

--- a/resource/lib/cf-functions.sh
+++ b/resource/lib/cf-functions.sh
@@ -617,10 +617,12 @@ function cf::create_service_broker() {
 
 function cf::enable_service_access() {
   local service=${1:?service null or not set}
-  local plan=${2:-}
-  local access_org=${3:-}
+  local broker=${2:-}
+  local plan=${3:-}
+  local access_org=${4:-}
 
   local args=("$service")
+  [ -n "$broker" ] && args+=(-b "$broker")
   [ -n "$plan" ] && args+=(-p "$plan")
   [ -n "$access_org" ] && args+=(-o "$access_org")
 


### PR DESCRIPTION
We want to deploy a third-party service broker multiple times in the same foundation (we deploy an instance for each org in our CF environment).
 
Since in this case the given service names are ambiguous, it is required to explicitly specify the service broker name when enabling the service access for an organization.

I modified the enable-service-access function and command, so that a `service_broker` parameter can be passed.
I also added the parameter to the test-scripts in the `itest` folder (but I did **not** run these tests).

I know that there has been a misleading naming (https://github.com/nulldriver/cf-cli-resource/issues/21) and thus on one hand, I'm not 100% sure whether it is a good idea to remove the backwards compatibility which was implemented to fix the naming issue - but on the other hand, the parameter `service_broker` is imho the best-fitting one for this PR (which is why I choose to remove the backwards compatibility).

In case you want to merge this request, let me know if the backwards compatibility should be kept (and another parameter name should be used) or whether the reuse of the `service_broker`-naming is okay.

Best regards

