### PR TITLE
Add the ability to use unbind-route-service

### DIFF
--- a/resource/commands/unbind-route-service.sh
+++ b/resource/commands/unbind-route-service.sh
@@ -1,0 +1,15 @@
+
+domain=$(get_option '.domain')
+service_instance=$(get_option '.service_instance')
+hostname=$(get_option '.hostname')
+path=$(get_option '.path')
+
+logger::info "Executing $(logger::highlight "$command"): $service_instance"
+
+cf::target "$org" "$space"
+
+args=("$domain" "$service_instance")
+[ -n "$hostname" ] && args+=(--hostname "$hostname")
+[ -n "$path" ] && args+=(--path "$path")
+
+cf::cf unbind-route-service "${args[@]}"


### PR DESCRIPTION
- The unbind-route-service command gives the ability to Unbind a service instance from an HTTP route as per the
cloudfoundry docs - http://cli.cloudfoundry.org/en-US/v6/unbind-route-service.html