### PR TITLE
Use registry-image instead of docker-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note: you must provide either `username` and `password` or `client_id` and `clie
 ```yml
 resource_types:
   - name: cf-cli-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: nulldriver/cf-cli-resource
       tag: latest


### PR DESCRIPTION
This enables the job to be executed without being privileged in Docker.
See https://github.com/concourse/registry-image-resource#registry-image-resource for details.

Co-authored-by: Leo Dias <leo@vw-dilab.com>