### PR TITLE
use yq.strenv() to handle multiline env values

### DIFF
--- a/resource/lib/util.sh
+++ b/resource/lib/util.sh
@@ -54,11 +54,11 @@ util::set_manifest_environment_variables() (
   for key in $(get_keys); do
     local value=$(get_value "$key")
     if has_named_app; then
-      name=$app_name key=$key value=$value yq --inplace '(.applications[] | select(.name == env(name)) | .env[env(key)]) = env(value)' "$manifest"
+      name=$app_name key=$key value=$value yq --inplace '(.applications[] | select(.name == env(name)) | .env[env(key)]) = strenv(value)' "$manifest"
     elif has_one_unnamed_app; then
-      name=$app_name key=$key value=$value yq --inplace '(.applications[0].env[env(key)]) = env(value)' "$manifest"
+      name=$app_name key=$key value=$value yq --inplace '(.applications[0].env[env(key)]) = strenv(value)' "$manifest"
     else
-      key=$key value=$value yq --inplace '.env[env(key)] = env(value)' "$manifest"
+      key=$key value=$value yq --inplace '.env[env(key)] = strenv(value)' "$manifest"
     fi
   done
 )


### PR DESCRIPTION
# Problem description
When upgrading from yq 3.x to 4.x, the behaviour regarding multiline changed.

# Steps to reproduce
## Setup
```bash
user@pc:/# cat test.sh
#!/bin/bash
yq --version
echo """---
applications:
  - env:
""" > manifest.yml

export manifest="manifest.yml"
export key="MYKEY"
export value='{
    "glossary": {
        "title": "example glossary",
    }
}'
echo "WRONG:"
yq '.env[env(key)] = env(value)' "$manifest"

echo "CORRECT:"
yq '.env[env(key)] = strenv(value)' "$manifest"
```

## Result
```bash
yq (https://github.com/mikefarah/yq/) version v4.30.6
WRONG:
---
applications:
  - env:
env:
  MYKEY: {"glossary": {"title": "example glossary"}}
CORRECT:
---
applications:
  - env:
env:
  MYKEY: |-
    {
        "glossary": {
            "title": "example glossary",
        }
    }
```
Especially when working with YAML and other newline-sensitive formats this is essential.

# Fix
Use yq.strenv() instead of yq.env()