### PR TITLE
Added wait option to the run-task command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,7 @@ Run a one-off task on an app
 | `task_name`        | *Optional* | All         | Name to give the task (generated if omitted)
 | `memory`           | *Optional* | All         | Memory limit (e.g. 256M, 1024M, 1G)
 | `disk_quota`       | *Optional* | All         | Disk limit (e.g. 256M, 1024M, 1G)
+| `wait`             | *Optional* | 7, 8        | Wait for the operation to complete
 
 ```yaml
 - put: cloud-foundry

--- a/resource/commands/run-task.sh
+++ b/resource/commands/run-task.sh
@@ -4,6 +4,7 @@ task_command=$(get_option '.task_command')
 task_name=$(get_option '.task_name')
 memory=$(get_option '.memory')
 disk_quota=$(get_option '.disk_quota')
+wait=$(get_option '.wait')
 
 logger::info "Executing #magenta(%s) on app #yellow(%s)" "$command" "$app_name"
 
@@ -20,5 +21,9 @@ fi
 [ -n "$task_name" ] && args+=(--name "$task_name")
 [ -n "$memory" ] && args+=(-m "$memory")
 [ -n "$disk_quota" ] && args+=(-k "$disk_quota")
+
+if ! cf::is_cf6 && [ "true" = "$wait" ]; then
+  args+=(--wait)
+fi
 
 cf::cf run-task "${args[@]}"


### PR DESCRIPTION
The cf cli version 7 and 8 support the wait option in the run-task command.